### PR TITLE
Add citation finder widget for Zotero items

### DIFF
--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -1,3 +1,4 @@
+export const POPUP_Y_OFFSET = 25;
 // Rename summary: powerupCodes.COOL_POOL -> powerupCodes.CITATION_POOL
 export const citationFormats = [
 	{

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,19 @@
 // Rename summary: abort sync handling and CITATION_POOL rename
 import {
-	declareIndexPlugin,
-	PropertyLocation,
-	PropertyType,
-	type RNPlugin,
-	SelectionType,
-	WidgetLocation,
+declareIndexPlugin,
+PropertyLocation,
+PropertyType,
+type RNPlugin,
+SelectionType,
+WidgetLocation,
 } from '@remnote/plugin-sdk';
 import { fetchLibraries } from './api/zotero';
-import { citationFormats, citationSourceOptions, powerupCodes } from './constants/constants';
+import {
+citationFormats,
+citationSourceOptions,
+POPUP_Y_OFFSET,
+powerupCodes,
+} from './constants/constants';
 import { itemTypes } from './constants/zoteroItemSchema';
 import { autoSync } from './services/autoSync';
 import {
@@ -30,6 +35,7 @@ import { LogType, logMessage } from './utils/logging';
 let autoSyncInterval: NodeJS.Timeout | undefined;
 let zoteroCitationRegistered = false;
 let wikiCitationRegistered = false;
+let citationWidgetId: string | undefined;
 
 // Helper functions for organizing registration logic
 
@@ -686,15 +692,45 @@ async function registerCommands(plugin: RNPlugin) {
 		},
 	});
 
-	const source = (await plugin.settings.getSetting('citation-source')) as string | undefined;
-	if (source === 'zotero') {
-		await registerZoteroCitationCommands(plugin);
-	} else if (source === 'wikipedia') {
-		await registerWikipediaCitationCommands(plugin);
-	} else {
-		await registerZoteroCitationCommands(plugin);
-		await registerWikipediaCitationCommands(plugin);
-	}
+const source = (await plugin.settings.getSetting('citation-source')) as
+string | undefined;
+if (source === 'zotero') {
+await registerZoteroCitationCommands(plugin);
+} else if (source === 'wikipedia') {
+await registerWikipediaCitationCommands(plugin);
+} else {
+await registerZoteroCitationCommands(plugin);
+await registerWikipediaCitationCommands(plugin);
+}
+
+const openFinder = async (mode: 'citation' | 'bib') => {
+const caret = await plugin.editor.getCaretPosition();
+await plugin.storage.setSession('citationFinderMode', mode);
+citationWidgetId = await plugin.window.openFloatingWidget('citationFinder', {
+top: caret ? caret.y + POPUP_Y_OFFSET : undefined,
+left: caret?.x,
+});
+};
+
+await plugin.app.registerCommand({
+id: 'insert-citation-at-cursor',
+name: 'Add/Edit Citation',
+description: 'Insert a citation from your Zotero library.',
+quickCode: 'icite',
+action: async () => {
+await openFinder('citation');
+},
+});
+
+await plugin.app.registerCommand({
+id: 'insert-bibliography-at-cursor',
+name: 'Add/Edit Bibliography',
+description: 'Insert a bibliography entry from your Zotero library.',
+quickCode: 'ibib',
+action: async () => {
+await openFinder('bib');
+},
+});
 
 	// await plugin.app.registerCommand({
 	// 	id: 'insert-citation-at-cursor',
@@ -738,10 +774,13 @@ async function registerCommands(plugin: RNPlugin) {
 }
 
 async function registerWidgets(plugin: RNPlugin) {
-	await plugin.app.registerWidget('syncStatusWidget', WidgetLocation.DocumentBelowTitle, {
-		dimensions: { height: 200, width: 500 },
-		powerupFilter: powerupCodes.ZOTERO_CONNECTOR_HOME,
-	});
+await plugin.app.registerWidget('syncStatusWidget', WidgetLocation.DocumentBelowTitle, {
+dimensions: { height: 200, width: 500 },
+powerupFilter: powerupCodes.ZOTERO_CONNECTOR_HOME,
+});
+await plugin.app.registerWidget('citationFinder', WidgetLocation.FloatingWidget, {
+dimensions: { height: 'auto', width: '320px' },
+});
 }
 
 async function onActivate(plugin: RNPlugin) {

--- a/src/widgets/citationFinder.css
+++ b/src/widgets/citationFinder.css
@@ -1,0 +1,34 @@
+#citation-finder-root {
+  background: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 0.75rem;
+  box-shadow: 0 2px 12px rgba(0,0,0,0.08);
+  padding: 0.5rem;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.citation-finder-input {
+  width: 100%;
+  padding: 0.4rem 0.6rem;
+  margin-bottom: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 0.5rem;
+  box-sizing: border-box;
+}
+
+.citation-finder-results {
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.citation-finder-item {
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  cursor: pointer;
+}
+
+.citation-finder-item.selected,
+.citation-finder-item:hover {
+  background: #f0f0f0;
+}

--- a/src/widgets/citationFinder.tsx
+++ b/src/widgets/citationFinder.tsx
@@ -1,0 +1,143 @@
+import './citationFinder.css';
+import {
+AppEvents,
+renderWidget,
+useAPIEventListener,
+usePlugin,
+useRunAsync,
+useTracker,
+type WidgetLocation,
+} from '@remnote/plugin-sdk';
+import * as React from 'react';
+import { powerupCodes } from '../constants/constants';
+import { fetchZoteroBibliography, fetchZoteroCitation } from '../services/citationHelpers';
+import { useSyncWidgetPositionWithCaret } from './hooks';
+
+interface ZoteroItem {
+id: string;
+key: string;
+title: string;
+}
+
+function CitationFinderWidget() {
+const plugin = usePlugin();
+
+const ctx = useRunAsync(
+async () => await plugin.widget.getWidgetContext<WidgetLocation.FloatingWidget>(),
+[]
+);
+
+const mode = useRunAsync(async () => {
+const m = (await plugin.storage.getSession('citationFinderMode')) as string | undefined;
+return m === 'bib' ? 'bib' : 'citation';
+}, []);
+
+const [query, setQuery] = React.useState('');
+const results =
+useTracker(
+async (rp) => {
+if (!query.trim()) return [] as ZoteroItem[];
+
+const token = await rp.richText.text(query).value();
+const remHits = await rp.search.search(token, undefined, {
+numResults: 50,
+});
+
+const out: ZoteroItem[] = [];
+for (const r of remHits) {
+if (!(await r.hasPowerup(powerupCodes.ZITEM))) continue;
+const key = await r.getPowerupProperty(powerupCodes.ZITEM, 'key');
+const title = await rp.richText.toString(r.text ?? []);
+if (key && title)
+out.push({ id: r._id, key: String(key), title: title.trim() });
+}
+return out;
+},
+[query]
+) ?? [];
+
+const floatingWidgetId = ctx?.floatingWidgetId;
+const hidden = results.length === 0 && query.length === 0;
+
+useSyncWidgetPositionWithCaret(floatingWidgetId, hidden);
+
+const [selectedIdx, setSelectedIdx] = React.useState(0);
+
+React.useEffect(() => {
+const keys = ['ArrowDown', 'ArrowUp', 'Enter', 'Escape'];
+if (!floatingWidgetId) return;
+if (!hidden) {
+plugin.window.stealKeys(floatingWidgetId, keys);
+} else {
+plugin.window.releaseKeys(floatingWidgetId, keys);
+}
+}, [hidden, floatingWidgetId, plugin]);
+
+useAPIEventListener(AppEvents.StealKeyEvent, floatingWidgetId, ({ key }) => {
+if (key === 'ArrowDown') setSelectedIdx((i) => Math.min(i + 1, results.length - 1));
+else if (key === 'ArrowUp') setSelectedIdx((i) => Math.max(i - 1, 0));
+else if (key === 'Enter') confirmSelection();
+else if (key === 'Escape')
+floatingWidgetId && plugin.window.closeFloatingWidget(floatingWidgetId);
+});
+
+React.useEffect(() => {
+if (!hidden) setSelectedIdx(0);
+}, [hidden]);
+
+async function confirmSelection() {
+const sel = results[selectedIdx];
+if (!sel) return;
+
+const text =
+mode === 'bib'
+? await fetchZoteroBibliography(plugin, sel.key)
+: await fetchZoteroCitation(plugin, sel.key);
+
+if (text) await plugin.editor.insertPlainText(text);
+floatingWidgetId && (await plugin.window.closeFloatingWidget(floatingWidgetId));
+}
+
+return (
+<div id="citation-finder-root" className={hidden ? 'hidden' : ''}>
+<input
+className="citation-finder-input"
+value={query}
+onChange={(e) => setQuery(e.target.value)}
+placeholder="Search Zotero items…"
+/>
+<div className="citation-finder-results">
+{results.map((it, idx) => (
+<button
+key={it.id}
+type="button"
+className={`citation-finder-item${idx === selectedIdx ? ' selected' : ''}`}
+onMouseEnter={() => setSelectedIdx(idx)}
+onClick={() => {
+setSelectedIdx(idx);
+confirmSelection();
+}}
+onKeyDown={(e) => {
+if (e.key === 'Enter' || e.key === ' ') {
+setSelectedIdx(idx);
+confirmSelection();
+}
+}}
+tabIndex={0}
+style={{
+width: '100%',
+textAlign: 'left',
+background: 'none',
+border: 'none',
+padding: 0,
+}}
+>
+{it.title}
+</button>
+))}
+</div>
+</div>
+);
+}
+
+renderWidget(CitationFinderWidget);

--- a/src/widgets/hooks.ts
+++ b/src/widgets/hooks.ts
@@ -1,0 +1,32 @@
+import { AppEvents, useAPIEventListener, usePlugin } from '@remnote/plugin-sdk';
+import * as React from 'react';
+import { POPUP_Y_OFFSET } from '../constants/constants';
+
+export const useSyncWidgetPositionWithCaret = (
+floatingWidgetId: string | undefined,
+hidden: boolean
+) => {
+const plugin = usePlugin();
+const caretPos = useCaretPosition();
+React.useEffect(() => {
+const effect = async () => {
+if (floatingWidgetId && caretPos) {
+await plugin.window.setFloatingWidgetPosition(floatingWidgetId, {
+top: caretPos.y + POPUP_Y_OFFSET,
+left: caretPos.x,
+});
+}
+};
+if (!hidden) effect();
+}, [caretPos?.x, caretPos?.y, floatingWidgetId, hidden, plugin, caretPos]);
+};
+
+const useCaretPosition = (): DOMRect | null => {
+  const plugin = usePlugin();
+  const [caret, setCaret] = React.useState<DOMRect | null>(null);
+  useAPIEventListener(AppEvents.EditorTextEdited, undefined, async () => {
+    const c = await plugin.editor.getCaretPosition();
+    setCaret(c ?? null);
+  });
+  return caret;
+};


### PR DESCRIPTION
## Summary
- implement floating citation finder widget for selecting Zotero items
- hook floating widget position to caret
- expose commands *Add/Edit Citation* and *Add/Edit Bibliography*
- register widget and constant

## Testing
- `npm run check-types`


------
https://chatgpt.com/codex/tasks/task_e_6873dd0afae8832482deb8cd1264da28