### PR TITLE
Add citation finder widget for Zotero items

### DIFF
--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -1,3 +1,4 @@
+export const POPUP_Y_OFFSET = 25;
 // Rename summary: powerupCodes.COOL_POOL -> powerupCodes.CITATION_POOL
 export const citationFormats = [
 	{

--- a/src/services/citationHelpers.ts
+++ b/src/services/citationHelpers.ts
@@ -2,67 +2,75 @@ import { BuiltInPowerupCodes, type Rem, type RNPlugin } from '@remnote/plugin-sd
 import { WIKIPEDIA_API_HEADERS, WIKIPEDIA_API_URL } from '../constants/constants';
 import { LogType, logMessage } from '../utils/logging';
 
-export async function extractSourceUrls(plugin: RNPlugin, rem: Rem): Promise<string[]> {
-	const sources = await rem.getSources();
-	const urls: string[] = [];
-
-	for (const source of sources) {
-		const md = await plugin.richText.toMarkdown(
-			await source.getPowerupPropertyAsRichText(BuiltInPowerupCodes.Link, 'URL')
-		);
-
-		// works for `[label](url)` *and* bare `https://…`
-		const linkMatch = /\((https?:\/\/[^)]+)\)/.exec(md);
-		const candidate = linkMatch ? linkMatch[1] : md.trim();
-
-		if (isValidUrl(candidate)) {
-			urls.push(candidate);
-		} else {
-			await logMessage(
-				plugin,
-				`Source ${source._id.slice(0, 8)}: extracted string is not a URL → “${candidate}”`,
-				LogType.Debug,
-				false
-			);
-		}
-	}
-
-	return urls;
+/* ──────────────────────────────────────────────────────────────────── */
+/*  Small util: choose Zotero base URL                                 */
+/* ──────────────────────────────────────────────────────────────────── */
+function zoteroBase(): string {
+    return process.env.NODE_ENV === 'development' ? '/zotero' : 'https://api.zotero.org';
 }
 
-function isValidUrl(url: string): boolean {
-	try {
-		new URL(url);
-		return true;
-	} catch {
-		return false;
-	}
-}
-
+/* ──────────────────────────────────────────────────────────────────── */
+/*  0 ▸ helper: current credentials + primary library info             */
+/* ──────────────────────────────────────────────────────────────────── */
 async function getLibraryInfo(plugin: RNPlugin) {
-	const apiKey = await plugin.settings.getSetting('zotero-api-key');
-	const userId = await plugin.settings.getSetting('zotero-user-id');
-	const libSetting = await plugin.settings.getSetting('zotero-library-id');
+    const apiKey = await plugin.settings.getSetting('zotero-api-key');
+    const userId = await plugin.settings.getSetting('zotero-user-id');
+    const libSetting = await plugin.settings.getSetting('zotero-library-id');
 
-	if (!apiKey || !userId) throw new Error('Zotero credentials not set');
+    if (!apiKey || !userId) throw new Error('Zotero credentials not set');
 
-	let libraryId = String(userId);
-	let libraryType: 'users' | 'groups' = 'users';
+    let libraryId = String(userId);
+    let libraryType: 'users' | 'groups' = 'users';
 
-	if (typeof libSetting === 'string' && libSetting.includes(':')) {
-		const [type, id] = libSetting.split(':');
-		libraryType = type === 'group' ? 'groups' : 'users';
-		libraryId = id;
-	}
-	return { apiKey: String(apiKey), libraryId, libraryType };
+    if (typeof libSetting === 'string' && libSetting.includes(':')) {
+        const [type, id] = libSetting.split(':');
+        libraryType = type === 'group' ? 'groups' : 'users';
+        libraryId = id;
+    }
+
+    return {
+        apiKey: String(apiKey),
+        primaryLibId: libraryId,
+        primaryLibType: libraryType,
+        userId: String(userId),
+    };
 }
+
+export async function extractSourceUrls(plugin: RNPlugin, rem: Rem): Promise<string[]> {
+    const sources = await rem.getSources();
+    const urls: string[] = [];
+
+    for (const source of sources) {
+        const md = await plugin.richText.toMarkdown(
+            await source.getPowerupPropertyAsRichText(BuiltInPowerupCodes.Link, 'URL')
+        );
+
+        const linkMatch = /(https?:\/\/[^)]+)/.exec(md);
+        const candidate = linkMatch ? linkMatch[1] : md.trim();
+
+        try {
+            new URL(candidate);
+            urls.push(candidate);
+        } catch {
+            await logMessage(
+                plugin,
+                `Source ${source._id.slice(0, 8)}: extracted string is not a URL → “${candidate}”`,
+                LogType.Debug,
+                false
+            );
+        }
+    }
+
+    return urls;
+}
+
 /**
  * Take an array of URLs, translate them with Wikimedia Citoid, push each item
  * into the configured Zotero library, and return the new item keys.
  */
 export async function sendUrlsToZotero(plugin: RNPlugin, urls: string[]): Promise<string[]> {
-	const { apiKey, libraryId, libraryType } = await getLibraryInfo(plugin);
-	const itemKeys: string[] = [];
+        const { apiKey, primaryLibId, primaryLibType } = await getLibraryInfo(plugin);
+        const itemKeys: string[] = [];
 
 	for (const url of urls) {
 		await logMessage(plugin, `▶ Translating ${url}`, LogType.Debug, false);
@@ -90,18 +98,18 @@ export async function sendUrlsToZotero(plugin: RNPlugin, urls: string[]): Promis
 			continue;
 		}
 
-		/* 2 ▸ POST to Zotero */
-		await logMessage(plugin, `⤴ Pushing item to Zotero`, LogType.Debug, false);
+                /* 2 ▸ POST to Zotero */
+                await logMessage(plugin, `⤴ Pushing item to Zotero`, LogType.Debug, false);
 
-		const postRes = await fetch(`https://api.zotero.org/${libraryType}/${libraryId}/items`, {
-			method: 'POST',
-			headers: {
-				'Content-Type': 'application/json',
-				'Zotero-API-Key': apiKey,
-				'Zotero-API-Version': '3', // explicit version = clearer errors
-			},
-			body: JSON.stringify([item]), // array per API spec
-		});
+                const postRes = await fetch(`${zoteroBase()}/${primaryLibType}/${primaryLibId}/items`, {
+                        method: 'POST',
+                        headers: {
+                                'Content-Type': 'application/json',
+                                'Zotero-API-Key': apiKey,
+                                'Zotero-API-Version': '3',
+                        },
+                        body: JSON.stringify([item]),
+                });
 
 		const bodyText = await postRes.text(); // we’ll need this for logging
 
@@ -176,33 +184,58 @@ export async function fetchZoteroFormatted(
 		((await plugin.settings.getSetting('citation-format')) as string | undefined) ??
 		'apa';
 
-	const { apiKey, libraryId, libraryType } = await getLibraryInfo(plugin);
+        const { apiKey, primaryLibId, primaryLibType, userId } = await getLibraryInfo(plugin);
 
-	const url =
-		`https://api.zotero.org/${libraryType}/${libraryId}/items/${itemKey}` +
-		`?include=${include}&style=${finalStyle}&linkwrap=0`; // no <a> tags
+        const primaryUrl =
+                `${zoteroBase()}/${primaryLibType}/${primaryLibId}/items/${itemKey}` +
+                `?include=${include}&style=${finalStyle}&linkwrap=0`;
 
-	const res = await fetch(url, { headers: { 'Zotero-API-Key': apiKey } });
+        const primary = await tryFetchFormatted(plugin, primaryUrl, apiKey);
+        if (primary) return primary;
 
-	if (!res.ok) {
-		const msg = await res.text();
-		await logMessage(plugin, `Zotero GET ${res.status}: ${msg}`, LogType.Warning, false);
-		return null;
-	}
+        if (primaryLibType === 'groups') {
+                const userUrl =
+                        `${zoteroBase()}/users/${userId}/items/${itemKey}` +
+                        `?include=${include}&style=${finalStyle}&linkwrap=0`;
 
-	try {
-		const json = await res.json();
-		const rawHtml = include === 'citation' ? json.citation : json.bib;
-		return stripHtml(rawHtml);
-	} catch (e) {
-		await logMessage(
-			plugin,
-			`Failed to parse Zotero ${include} JSON for ${itemKey}: ${String(e)}`,
-			LogType.Error,
-			false
-		);
-		return null;
-	}
+                const personal = await tryFetchFormatted(plugin, userUrl, apiKey);
+                if (personal) return personal;
+        }
+
+        return null;
+}
+
+async function tryFetchFormatted(
+        plugin: RNPlugin,
+        url: string,
+        apiKey: string
+): Promise<string | null> {
+        let res: Response;
+        try {
+                res = await fetch(url, {
+                        headers: { 'Zotero-API-Key': apiKey, Accept: 'application/json' },
+                });
+        } catch (e) {
+                await logMessage(plugin, `Fetch failed for ${url}: ${String(e)}`, LogType.Warning, false);
+                return null;
+        }
+
+        if (!res.ok) return null;
+
+        const ctype = res.headers.get('content-type') ?? '';
+        let rawHtml = '';
+        try {
+                if (ctype.includes('application/json')) {
+                        const json = await res.json();
+                        rawHtml = json.citation ?? json.bib ?? '';
+                } else {
+                        rawHtml = await res.text();
+                }
+        } catch {
+                return null;
+        }
+
+        return rawHtml ? stripHtml(rawHtml) : null;
 }
 export const fetchZoteroCitation = (plugin: RNPlugin, itemKey: string, style?: string) =>
 	fetchZoteroFormatted(plugin, itemKey, 'citation', style);

--- a/src/widgets/citationFinder.css
+++ b/src/widgets/citationFinder.css
@@ -1,0 +1,41 @@
+#citation-finder-root {
+  background: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 0.75rem;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+  padding: 0.5rem;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.citation-finder-input {
+  width: 100%;
+  padding: 0.4rem 0.6rem;
+  margin-bottom: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 0.5rem;
+  box-sizing: border-box;
+}
+
+.citation-finder-results {
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.citation-finder-item {
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  color: var(--rn-clr-content-primary);
+}
+
+/* hover and selected state: blue background + white text */
+.citation-finder-item:hover,
+.citation-finder-item.selected {
+  background: var(--rn-clr-interactive-primary, #2977ff);
+  color: var(--rn-clr-content-on-primary, #ffffff);
+}

--- a/src/widgets/citationFinder.tsx
+++ b/src/widgets/citationFinder.tsx
@@ -1,0 +1,178 @@
+import './citationFinder.css';
+import {
+    AppEvents,
+    renderWidget,
+    useAPIEventListener,
+    usePlugin,
+    useRunAsync,
+    useTracker,
+    type WidgetLocation,
+} from '@remnote/plugin-sdk';
+import * as React from 'react';
+import { POPUP_Y_OFFSET, powerupCodes } from '../constants/constants';
+import { fetchZoteroBibliography, fetchZoteroCitation } from '../services/citationHelpers';
+import { useSyncWidgetPositionWithCaret } from './hooks';
+
+interface ZoteroItem {
+    id: string;
+    key: string;
+    title: string;
+}
+
+function CitationFinderWidget() {
+    const plugin = usePlugin();
+
+    /* ──────────────────────────────────────────
+     * floating-widget context & id
+     * ────────────────────────────────────────── */
+    const ctx = useRunAsync(
+        async () => await plugin.widget.getWidgetContext<WidgetLocation.FloatingWidget>(),
+        []
+    );
+    const floatingWidgetId = ctx?.floatingWidgetId;
+
+    /* ──────────────────────────────────────────
+     * initial placement – poll until caret appears
+     * ────────────────────────────────────────── */
+    useRunAsync(async () => {
+        if (!floatingWidgetId) return;
+
+        const cached = (await plugin.storage.getSession('citationFinderInitialPos')) as
+            | { x: number; y: number }
+            | null;
+        if (cached) {
+            await plugin.window.setFloatingWidgetPosition(floatingWidgetId, {
+                top: cached.y + POPUP_Y_OFFSET,
+                left: cached.x,
+            });
+        }
+
+        let tries = 0;
+        const id = window.setInterval(async () => {
+            const caret = await plugin.editor.getCaretPosition();
+            if (caret) {
+                await plugin.window.setFloatingWidgetPosition(floatingWidgetId, {
+                    top: caret.y + POPUP_Y_OFFSET,
+                    left: caret.x,
+                });
+                window.clearInterval(id);
+            }
+            if (++tries > 20) window.clearInterval(id);
+        }, 100);
+    }, [floatingWidgetId]);
+
+    /* keep following the caret once the user resumes typing */
+    useSyncWidgetPositionWithCaret(floatingWidgetId, false);
+
+    /* ─────────────────────────────
+     * citation vs bibliography mode
+     * ───────────────────────────── */
+    const mode = useRunAsync(async () => {
+        const m = (await plugin.storage.getSession('citationFinderMode')) as string | undefined;
+        return m === 'bib' ? 'bib' : 'citation';
+    }, []);
+
+    /* ─────────────────────────────
+     * incremental search
+     * ───────────────────────────── */
+    const [query, setQuery] = React.useState('');
+    const results =
+        useTracker(
+            async (rp) => {
+                if (!query.trim()) return [] as ZoteroItem[];
+
+                const token = await rp.richText.text(query).value();
+                const hits = await rp.search.search(token, undefined, { numResults: 50 });
+
+                const out: ZoteroItem[] = [];
+                for (const r of hits) {
+                    if (!(await r.hasPowerup(powerupCodes.ZITEM))) continue;
+                    const key = await r.getPowerupProperty(powerupCodes.ZITEM, 'key');
+                    const title = await rp.richText.toString(r.text ?? []);
+                    if (key && title) out.push({ id: r._id, key: String(key), title: title.trim() });
+                }
+                return out;
+            },
+            [query]
+        ) ?? [];
+
+    /* ─────────────────────────────
+     * hot-key handling
+     * ───────────────────────────── */
+    const STEAL = ['down', 'up', 'enter', 'tab', 'escape', 'ArrowDown', 'ArrowUp'];
+
+    React.useEffect(() => {
+        if (!floatingWidgetId) return;
+        plugin.window.stealKeys(floatingWidgetId, STEAL);
+        return () => {
+            plugin.window.releaseKeys(floatingWidgetId, STEAL);
+        };
+    }, [floatingWidgetId, plugin]);
+
+    const [selectedIdx, setSelectedIdx] = React.useState(0);
+    React.useEffect(() => setSelectedIdx(0), []);
+
+    useAPIEventListener(AppEvents.StealKeyEvent, floatingWidgetId, ({ key }) => {
+        const k = key.toLowerCase();
+        if (k === 'arrowdown' || k === 'down')
+            setSelectedIdx((i) => Math.min(i + 1, results.length - 1));
+        else if (k === 'arrowup' || k === 'up') setSelectedIdx((i) => Math.max(i - 1, 0));
+        else if (k === 'enter' || k === 'tab') confirmSelection();
+        else if (k === 'escape') floatingWidgetId && plugin.window.closeFloatingWidget(floatingWidgetId);
+    });
+
+    /* ─────────────────────────────
+     * insert, close, focus
+     * ───────────────────────────── */
+    async function confirmSelection() {
+        const sel = results[selectedIdx];
+        if (!sel) return;
+
+        if (floatingWidgetId) plugin.window.closeFloatingWidget(floatingWidgetId);
+
+        const text =
+            mode === 'bib'
+                ? await fetchZoteroBibliography(plugin, sel.key)
+                : await fetchZoteroCitation(plugin, sel.key);
+
+        if (text) await plugin.editor.insertPlainText(text);
+    }
+
+    /* ─────────────────────────────
+     * render UI
+     * ───────────────────────────── */
+    return (
+        <div id="citation-finder-root">
+            <input
+                className="citation-finder-input"
+                autoFocus
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Search Zotero items…"
+            />
+
+            {results.length > 0 && (
+                <div className="citation-finder-results">
+                    {results.map((it, idx) => (
+                        <button
+                            key={it.id}
+                            type="button"
+                            className={`citation-finder-item${idx === selectedIdx ? ' selected' : ''}`}
+                            onMouseEnter={() => setSelectedIdx(idx)}
+                            onClick={() => {
+                                setSelectedIdx(idx);
+                                confirmSelection();
+                            }}
+                            tabIndex={-1}
+                        >
+                            {it.title}
+                        </button>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}
+
+renderWidget(CitationFinderWidget);
+

--- a/src/widgets/hooks.ts
+++ b/src/widgets/hooks.ts
@@ -1,0 +1,32 @@
+import { AppEvents, useAPIEventListener, usePlugin } from '@remnote/plugin-sdk';
+import * as React from 'react';
+import { POPUP_Y_OFFSET } from '../constants/constants';
+
+export const useSyncWidgetPositionWithCaret = (
+    floatingWidgetId: string | undefined,
+    hidden: boolean
+) => {
+    const plugin = usePlugin();
+    const caretPos = useCaretPosition();
+    React.useEffect(() => {
+        const effect = async () => {
+            if (floatingWidgetId && caretPos) {
+                await plugin.window.setFloatingWidgetPosition(floatingWidgetId, {
+                    top: caretPos.y + POPUP_Y_OFFSET,
+                    left: caretPos.x,
+                });
+            }
+        };
+        if (!hidden) effect();
+    }, [caretPos?.x, caretPos?.y, floatingWidgetId, hidden, plugin, caretPos]);
+};
+
+const useCaretPosition = (): DOMRect | null => {
+    const plugin = usePlugin();
+    const [caret, setCaret] = React.useState<DOMRect | null>(null);
+    useAPIEventListener(AppEvents.EditorTextEdited, undefined, async () => {
+        const c = await plugin.editor.getCaretPosition();
+        setCaret(c ?? null);
+    });
+    return caret;
+};


### PR DESCRIPTION
## Summary
- implement floating citation finder widget for selecting Zotero items
- hook floating widget position to caret
- expose commands *Add/Edit Citation* and *Add/Edit Bibliography*
- register widget and constant
- fix widget file name so sandbox build loads
- refine widget keyboard control and Zotero fetch helpers

## Testing
- `npm run check-types`


------
https://chatgpt.com/codex/tasks/task_e_6873dd0afae8832482deb8cd1264da28