### PR TITLE
Add library bullet for library sync

### DIFF
--- a/src/services/iconCSS.ts
+++ b/src/services/iconCSS.ts
@@ -9,9 +9,10 @@ const iconTagMap: Record<string, string> = {
 	collection: 'collection',
 	'zotero-collection': 'collection',
 	coolPool: 'collection',
-	'zotero-unfiled-items': 'unfiled',
-	'zotero-synced-library': 'library',
-	'zotero-item': 'document',
+        'zotero-unfiled-items': 'unfiled',
+        'zotero-synced-library': 'library',
+        'zotero-library-sync': 'library',
+        'zotero-item': 'document',
 	zitem: 'document',
 
 	/* ─── Zotero Connector power‑ups ─── */
@@ -82,9 +83,9 @@ function iconCSS(tag: string, base: string, url: string): string {
 	const light = `${url}/${base}-light.svg`;
 
 	// Elements we touch ------------------------------------------------------
-	const coreRing = `${both(tag, '.rem-bullet__core')}, ${both(tag, '.rem-bullet__ring')}`;
-	const inner = both(tag, '.perfect-circle__inner');
-	const bullet = both(tag, '.rn-rem-bullet');
+        const coreRing = `${both(tag, '.rem-bullet__core')}, ${both(tag, '.rem-bullet__ring')}`;
+        const inner = both(tag, '.perfect-circle__inner');
+        const bullet = `${both(tag, '.rn-rem-bullet')}, ${both(tag, '.rn-document-bullet')}`;
 
 	let css = '';
 


### PR DESCRIPTION
## Summary
- map `zotero-library-sync` to the library icon
- ensure document bullets also get the custom icon

## Testing
- `npm run check-types`


------
https://chatgpt.com/codex/tasks/task_e_687403b1f39c8324808558195cd5ee7c