### PR TITLE
Add library icon to Library Sync bullets

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -745,7 +745,10 @@ async function registerWidgets(plugin: RNPlugin) {
 }
 
 async function onActivate(plugin: RNPlugin) {
-	await registerSettings(plugin);
+       // Register custom bullet icons at startup so library pages
+       // immediately display the correct library icon
+       await registerIconCSS(plugin);
+       await registerSettings(plugin);
 	await registerPowerups(plugin);
 	const homePage = await ensureZoteroLibraryRemExists(plugin);
 	if (homePage) {


### PR DESCRIPTION
## Summary
- ensure custom icons are registered during plugin activation
- this allows the Zotero Library Sync power‑up to display the library icon bullet immediately

## Testing
- `npm run check-types`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687403b1f39c8324808558195cd5ee7c