### PR TITLE
Implement dynamic theme support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ import { registerItemPowerups } from './services/zoteroSchemaToRemNote';
 import { release } from './sync/syncLock';
 import { ZoteroSyncManager } from './sync/zoteroSyncManager';
 import { LogType, logMessage } from './utils/logging';
+import { applyTheme, detectDarkMode, setupThemeDetection } from './utils/theme';
 
 let autoSyncInterval: NodeJS.Timeout | undefined;
 let zoteroCitationRegistered = false;
@@ -706,7 +707,7 @@ async function registerDebugCommands(plugin: RNPlugin) {
 		description: 'Registers the icon CSS for Zotero Connector.',
 		quickCode: 'ric',
 		action: async () => {
-			await registerIconCSS(plugin);
+                        await registerIconCSS(plugin, detectDarkMode());
 			plugin.app.toast('Icon CSS registered successfully!');
 		},
 	});
@@ -834,7 +835,9 @@ async function registerCommands(plugin: RNPlugin) {
 }
 
 async function onActivate(plugin: RNPlugin) {
-	await registerSettings(plugin);
+        setupThemeDetection(plugin);
+        await applyTheme(plugin, detectDarkMode());
+        await registerSettings(plugin);
 	await registerPowerups(plugin);
 	const homePage = await ensureZoteroLibraryRemExists(plugin);
 	if (homePage) {
@@ -887,8 +890,8 @@ async function onActivate(plugin: RNPlugin) {
 		}, 500);
 	}
 
-	plugin.track(async (reactivePlugin) => {
-		await registerIconCSS(plugin);
+        plugin.track(async (reactivePlugin) => {
+                await registerIconCSS(plugin, detectDarkMode());
 		const debugMode = await isDebugMode(reactivePlugin);
 		if (debugMode && !debugRegistered) {
 			plugin.app.toast('Debug Mode Enabled; Registering Debug Tools for Zotero Connector...');

--- a/src/services/iconCSS.ts
+++ b/src/services/iconCSS.ts
@@ -27,9 +27,9 @@ function both(tag: string, inner: string): string {
 /*───────────────────────────────────────────────────────────────────────────*/
 /* Per‑tag CSS generator                                                    */
 /*───────────────────────────────────────────────────────────────────────────*/
-function iconCSS(tag: string, base: string, url: string): string {
-	const dark = `${url}/${base}-dark.svg`;
-	const light = `${url}/${base}-light.svg`;
+function iconCSS(tag: string, base: string, url: string, darkMode: boolean): string {
+        const dark = `${url}/${base}-dark.svg`;
+        const light = `${url}/${base}-light.svg`;
 
 	// Elements we touch ------------------------------------------------------
 	const coreRing = `${both(tag, '.rem-bullet__core')}, ${both(tag, '.rem-bullet__ring')}`;
@@ -46,42 +46,33 @@ function iconCSS(tag: string, base: string, url: string): string {
 		'--perfect-circle-scale': '10', // force scale(1)
 	});
 
-	/* 3️⃣  Dark‑theme icon */
-	const bgDecl = {
-		'background-image': `url("${dark}")`,
-		'background-repeat': 'no-repeat',
-		'background-position': 'center',
-		'background-size': 'contain',
-	} as const;
-	css += rule(inner, bgDecl);
+        const bgDecl = {
+                'background-image': `url("${darkMode ? dark : light}")`,
+                'background-repeat': 'no-repeat',
+                'background-position': 'center',
+                'background-size': 'contain',
+        } as const;
+        css += rule(inner, bgDecl);
 
-	/* 4️⃣  Light‑theme override */
-	css += `@media (prefers-color-scheme: light) {\n`;
-	css += rule(inner, {
-		...bgDecl,
-		'background-image': `url("${light}")`,
-	});
-	css += `}\n`;
-
-	return css;
+        return css;
 }
 
 /*───────────────────────────────────────────────────────────────────────────*/
 /* Build complete stylesheet                                               */
 /*───────────────────────────────────────────────────────────────────────────*/
-function buildCSS(): string {
+function buildCSS(darkMode: boolean): string {
 	const base =
 		'https://raw.githubusercontent.com/coldenate/zotero-remnote-connector/refs/heads/main/public/icons/';
-	let css = '/* Zotero Connector icon overrides */\n';
-	for (const [tag, file] of Object.entries(iconTagMap)) css += iconCSS(tag, file, base);
-	return css;
+        let css = '/* Zotero Connector icon overrides */\n';
+        for (const [tag, file] of Object.entries(iconTagMap)) css += iconCSS(tag, file, base, darkMode);
+        return css;
 }
 
 /*───────────────────────────────────────────────────────────────────────────*/
 /* RemNote plugin entry                                                    */
 /*───────────────────────────────────────────────────────────────────────────*/
-export async function registerIconCSS(plugin: RNPlugin): Promise<void> {
-	const css = buildCSS();
+export async function registerIconCSS(plugin: RNPlugin, darkMode: boolean): Promise<void> {
+        const css = buildCSS(darkMode);
 	await logMessage(
 		plugin,
 		`[Zotero Connector-Icons] injecting ${css.length} chars`,

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -1,0 +1,41 @@
+import { AppEvents, type RNPlugin } from '@remnote/plugin-sdk';
+import { registerIconCSS } from '../services/iconCSS';
+
+export function detectDarkMode(): boolean {
+  if (typeof document !== 'undefined' && document.body) {
+    const bodyClasses = document.body.className.split(' ');
+    if (bodyClasses.includes('dark')) return true;
+    if (bodyClasses.includes('light')) return false;
+  }
+
+  if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    return true;
+  }
+
+  console.warn(
+    'Dark mode detection failed. Defaulting to dark mode.',
+    'Consider checking your system settings.',
+    "Or use the 'auto-switch-theme' setting in the plugin."
+  );
+  return true;
+}
+
+function citationFinderThemeCSS(dark: boolean): string {
+  if (dark) {
+    return `#citation-finder-root{background:#2b2b2b;border:1px solid #555;color:#ddd;box-shadow:0 2px 12px rgba(0,0,0,0.5);}\n` +
+           `#citation-finder-input{background:#1f1f1f;border:1px solid #555;color:#ddd;}`;
+  }
+  return `#citation-finder-root{background:#fff;border:1px solid #e0e0e0;color:#222;box-shadow:0 2px 12px rgba(0,0,0,0.08);}\n` +
+         `#citation-finder-input{background:#fff;border:1px solid #ccc;color:#222;}`;
+}
+
+export async function applyTheme(plugin: RNPlugin, dark: boolean): Promise<void> {
+  await registerIconCSS(plugin, dark);
+  await plugin.app.registerCSS('citation-finder-theme', citationFinderThemeCSS(dark));
+}
+
+export function setupThemeDetection(plugin: RNPlugin): void {
+  plugin.event.addListener(AppEvents.setDarkMode, undefined, (dark: boolean) => {
+    applyTheme(plugin, dark).catch(() => {});
+  });
+}


### PR DESCRIPTION
## Summary
- add theme utilities to detect and react to dark mode
- switch icon CSS generation to use current theme
- register icon and widget styles according to dark or light mode

## Testing
- `npm run check-types`

------
https://chatgpt.com/codex/tasks/task_e_68749014a03483248daea7a86460c0c2