### PR TITLE
Add setting to control AutoSort behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Additional diagnostic commands become available when **Debug Mode** is enabled.
 -   **Items in Multiple Collections Display Behavior** – choose `Portal` to link all instances of an item or `Reference` to create separate copies in each collection.
 -   **Disable Auto Sync** – prevents automatic synchronization every five minutes.
 -   **Simple Syncing Mode** – skips metadata (notes, dates, etc.) when importing items.
+-   **Auto Sort Library Rem** – adds the Auto Sort powerup to the library page.
 -   **Citation Format** – formatting style for citations and bibliographies (APA, MLA, etc.).
 -   **Citation Source** – choose where citation data comes from (`Zotero`, `Wikipedia`, or `Both`).
 -   **Debug Mode (Zotero Connector)** – exposes extra diagnostic commands and enables verbose logging. (please use this when reporting bugs and sending console logs! 🙏)

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Additional diagnostic commands become available when **Debug Mode** is enabled.
 
     ![Final Settings](.github/assets/final.png)
 
-<!-- 
+<!--
 ## Settings Reference
 
 -   **Zotero UserID** – your Zotero account ID from the Zotero API settings page.

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,7 +7,7 @@
 	"version": {
 		"major": 1,
 		"minor": 0,
-		"patch": 6
+		"patch": 8
 	},
 	"theme": [],
 	"enableOnMobile": true,

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -3,6 +3,7 @@ export const selectNextKeyID = 'selectNextKey';
 export const selectPreviousKeyID = 'selectPreviousKey';
 export const selectItemKeyID = 'selectItemKey';
 export const escapeKeyID = 'escapeKey';
+export const autoSortLibrarySettingID = 'auto-sort-library-rem';
 
 export const citationFormats = [
 	{

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,15 +8,15 @@ import {
 } from '@remnote/plugin-sdk';
 import { fetchLibraries } from './api/zotero';
 import {
+	autoSortLibrarySettingID,
 	citationFormats,
-        citationSourceOptions,
-        escapeKeyID,
-        POPUP_Y_OFFSET,
-        powerupCodes,
-        autoSortLibrarySettingID,
-        selectItemKeyID,
-        selectNextKeyID,
-        selectPreviousKeyID,
+	citationSourceOptions,
+	escapeKeyID,
+	POPUP_Y_OFFSET,
+	powerupCodes,
+	selectItemKeyID,
+	selectNextKeyID,
+	selectPreviousKeyID,
 } from './constants/constants';
 import { itemTypes } from './constants/zoteroItemSchema';
 import { autoSync } from './services/autoSync';
@@ -29,8 +29,8 @@ import {
 	sendUrlsToZotero,
 } from './services/citationHelpers';
 import {
-        ensureZoteroLibraryRemExists,
-        updateLibraryRemAutoSort,
+	ensureZoteroLibraryRemExists,
+	updateLibraryRemAutoSort,
 } from './services/ensureUIPrettyZoteroRemExist';
 import { registerIconCSS } from './services/iconCSS';
 import { createRem, markAbortRequested } from './services/pluginIO';
@@ -112,21 +112,21 @@ async function registerSettings(plugin: RNPlugin) {
 		defaultValue: true,
 	});
 
-        await plugin.settings.registerBooleanSetting({
-                id: 'simple-mode',
-                title: 'Simple Syncing Mode',
-                description:
-                        '(not recommended) Enables Simple importing of Zotero Items. Toggling this ON will AVOID importing any metadata for a Zotero item. For ex, notes, date accessed, etc.',
-                defaultValue: false,
-        });
+	await plugin.settings.registerBooleanSetting({
+		id: 'simple-mode',
+		title: 'Simple Syncing Mode',
+		description:
+			'(not recommended) Enables Simple importing of Zotero Items. Toggling this ON will AVOID importing any metadata for a Zotero item. For ex, notes, date accessed, etc.',
+		defaultValue: false,
+	});
 
-        await plugin.settings.registerBooleanSetting({
-                id: autoSortLibrarySettingID,
-                title: 'Auto Sort Library Rem',
-                description:
-                        "Automatically add RemNote's Auto Sort powerup to the Zotero Connector library page.",
-                defaultValue: true,
-        });
+	await plugin.settings.registerBooleanSetting({
+		id: autoSortLibrarySettingID,
+		title: 'Auto Sort Library Rem',
+		description:
+			"Automatically add RemNote's Auto Sort powerup to the Zotero Connector library page.",
+		defaultValue: true,
+	});
 
 	await plugin.settings.registerDropdownSetting({
 		id: 'citation-format',
@@ -867,16 +867,16 @@ async function onActivate(plugin: RNPlugin) {
 			);
 		}
 	}
-        await registerWidgets(plugin);
-        await handleLibrarySwitch(plugin);
-        await registerCommands(plugin);
+	await registerWidgets(plugin);
+	await handleLibrarySwitch(plugin);
+	await registerCommands(plugin);
 
-        plugin.event.addListener(AppEvents.SettingChanged, undefined, async () => {
-                const autoSortLibrary = (await plugin.settings.getSetting(
-                        autoSortLibrarySettingID
-                )) as boolean | undefined;
-                await updateLibraryRemAutoSort(plugin, Boolean(autoSortLibrary));
-        });
+	plugin.event.addListener(AppEvents.SettingChanged, undefined, async () => {
+		const autoSortLibrary = (await plugin.settings.getSetting(autoSortLibrarySettingID)) as
+			| boolean
+			| undefined;
+		await updateLibraryRemAutoSort(plugin, Boolean(autoSortLibrary));
+	});
 
 	const multiInit = (await plugin.settings.getSetting('sync-multiple-libraries')) as
 		| boolean
@@ -895,12 +895,12 @@ async function onActivate(plugin: RNPlugin) {
 	let lastApiKey: string | undefined;
 	let lastUserId: string | undefined;
 	let lastLibrary: string | undefined;
-        let lastDisable: boolean | undefined;
-        let lastMulti: boolean | undefined;
-        let lastCitationSource: string | undefined;
-        let lastAutoSortLibrary: boolean | undefined;
-        let debugRegistered = false;
-        let syncTimeout: NodeJS.Timeout | undefined;
+	let lastDisable: boolean | undefined;
+	let lastMulti: boolean | undefined;
+	let lastCitationSource: string | undefined;
+	let lastAutoSortLibrary: boolean | undefined;
+	let debugRegistered = false;
+	let syncTimeout: NodeJS.Timeout | undefined;
 
 	function scheduleSync(p: RNPlugin) {
 		if (syncTimeout) {
@@ -987,10 +987,10 @@ async function onActivate(plugin: RNPlugin) {
 			}
 		}
 
-                const citationSource = (await reactivePlugin.settings.getSetting('citation-source')) as
-                        | string
-                        | undefined;
-                if (citationSource !== lastCitationSource) {
+		const citationSource = (await reactivePlugin.settings.getSetting('citation-source')) as
+			| string
+			| undefined;
+		if (citationSource !== lastCitationSource) {
 			if (citationSource === 'zotero') {
 				await registerZoteroCitationCommands(plugin);
 			} else if (citationSource === 'wikipedia') {
@@ -999,20 +999,20 @@ async function onActivate(plugin: RNPlugin) {
 				await registerZoteroCitationCommands(plugin);
 				await registerWikipediaCitationCommands(plugin);
 			}
-                        lastCitationSource = citationSource;
-                        await plugin.app.toast(
-                                'Citation source changed. Reload the app to unregister old commands.'
-                        );
-                }
+			lastCitationSource = citationSource;
+			await plugin.app.toast(
+				'Citation source changed. Reload the app to unregister old commands.'
+			);
+		}
 
-                const autoSortLibrary = (await reactivePlugin.settings.getSetting(autoSortLibrarySettingID)) as
-                        | boolean
-                        | undefined;
-                if (autoSortLibrary !== lastAutoSortLibrary) {
-                        await updateLibraryRemAutoSort(reactivePlugin, Boolean(autoSortLibrary));
-                        lastAutoSortLibrary = autoSortLibrary;
-                }
-        });
+		const autoSortLibrary = (await reactivePlugin.settings.getSetting(
+			autoSortLibrarySettingID
+		)) as boolean | undefined;
+		if (autoSortLibrary !== lastAutoSortLibrary) {
+			await updateLibraryRemAutoSort(reactivePlugin, Boolean(autoSortLibrary));
+			lastAutoSortLibrary = autoSortLibrary;
+		}
+	});
 
 	await plugin.app.waitForInitialSync();
 	if (!isNewDebugMode) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -867,9 +867,16 @@ async function onActivate(plugin: RNPlugin) {
 			);
 		}
 	}
-	await registerWidgets(plugin);
-	await handleLibrarySwitch(plugin);
-	await registerCommands(plugin);
+        await registerWidgets(plugin);
+        await handleLibrarySwitch(plugin);
+        await registerCommands(plugin);
+
+        plugin.event.addListener(AppEvents.SettingChanged, undefined, async () => {
+                const autoSortLibrary = (await plugin.settings.getSetting(
+                        autoSortLibrarySettingID
+                )) as boolean | undefined;
+                await updateLibraryRemAutoSort(plugin, Boolean(autoSortLibrary));
+        });
 
 	const multiInit = (await plugin.settings.getSetting('sync-multiple-libraries')) as
 		| boolean

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,10 @@ import {
 	fetchZoteroCitation,
 	sendUrlsToZotero,
 } from './services/citationHelpers';
-import { ensureZoteroLibraryRemExists } from './services/ensureUIPrettyZoteroRemExist';
+import {
+        ensureZoteroLibraryRemExists,
+        updateLibraryRemAutoSort,
+} from './services/ensureUIPrettyZoteroRemExist';
 import { registerIconCSS } from './services/iconCSS';
 import { createRem, markAbortRequested } from './services/pluginIO';
 import { registerItemPowerups } from './services/zoteroSchemaToRemNote';
@@ -999,7 +1002,7 @@ async function onActivate(plugin: RNPlugin) {
                         | boolean
                         | undefined;
                 if (autoSortLibrary !== lastAutoSortLibrary) {
-                        await ensureZoteroLibraryRemExists(reactivePlugin);
+                        await updateLibraryRemAutoSort(reactivePlugin, Boolean(autoSortLibrary));
                         lastAutoSortLibrary = autoSortLibrary;
                 }
         });

--- a/src/services/ensureUIPrettyZoteroRemExist.ts
+++ b/src/services/ensureUIPrettyZoteroRemExist.ts
@@ -1,5 +1,5 @@
 import { BuiltInPowerupCodes, type Rem, type RNPlugin } from '@remnote/plugin-sdk';
-import { powerupCodes, autoSortLibrarySettingID } from '../constants/constants';
+import { autoSortLibrarySettingID, powerupCodes } from '../constants/constants';
 import { LogType, logMessage } from '../utils/logging';
 
 export async function ensureZoteroLibraryRemExists(plugin: RNPlugin) {
@@ -34,30 +34,30 @@ export async function ensureZoteroLibraryRemExists(plugin: RNPlugin) {
 		}
 	}
 
-        if (homeRem) {
-                await homeRem.setText(['Zotero Connector Home Page']);
-                if (!(await homeRem.hasPowerup(powerupCodes.ZOTERO_CONNECTOR_HOME))) {
-                        await homeRem.addPowerup(powerupCodes.ZOTERO_CONNECTOR_HOME);
-                }
-                const autoSortEnabled = (await plugin.settings.getSetting(autoSortLibrarySettingID)) as
-                        | boolean
-                        | undefined;
-                if (autoSortEnabled) {
-                        if (!(await homeRem.hasPowerup(BuiltInPowerupCodes.AutoSort))) {
-                                await homeRem.addPowerup(BuiltInPowerupCodes.AutoSort);
-                        }
-                } else {
-                        if (await homeRem.hasPowerup(BuiltInPowerupCodes.AutoSort)) {
-                                await homeRem.removePowerup(BuiltInPowerupCodes.AutoSort);
-                        }
-                }
-                if (await homeRem.hasPowerup(powerupCodes.ZOTERO_SYNCED_LIBRARY)) {
-                        await homeRem.removePowerup(powerupCodes.ZOTERO_SYNCED_LIBRARY);
-                }
-                await plugin.storage.setSynced('zoteroLibraryRemId', homeRem._id);
-                logMessage(plugin, 'Zotero Connector Home Page already exists', LogType.Info, false);
-                return homeRem;
-        }
+	if (homeRem) {
+		await homeRem.setText(['Zotero Connector Home Page']);
+		if (!(await homeRem.hasPowerup(powerupCodes.ZOTERO_CONNECTOR_HOME))) {
+			await homeRem.addPowerup(powerupCodes.ZOTERO_CONNECTOR_HOME);
+		}
+		const autoSortEnabled = (await plugin.settings.getSetting(autoSortLibrarySettingID)) as
+			| boolean
+			| undefined;
+		if (autoSortEnabled) {
+			if (!(await homeRem.hasPowerup(BuiltInPowerupCodes.AutoSort))) {
+				await homeRem.addPowerup(BuiltInPowerupCodes.AutoSort);
+			}
+		} else {
+			if (await homeRem.hasPowerup(BuiltInPowerupCodes.AutoSort)) {
+				await homeRem.removePowerup(BuiltInPowerupCodes.AutoSort);
+			}
+		}
+		if (await homeRem.hasPowerup(powerupCodes.ZOTERO_SYNCED_LIBRARY)) {
+			await homeRem.removePowerup(powerupCodes.ZOTERO_SYNCED_LIBRARY);
+		}
+		await plugin.storage.setSynced('zoteroLibraryRemId', homeRem._id);
+		logMessage(plugin, 'Zotero Connector Home Page already exists', LogType.Info, false);
+		return homeRem;
+	}
 
 	await logMessage(plugin, 'Zotero Connector Home Page Ensured', LogType.Info, false);
 
@@ -70,13 +70,13 @@ export async function ensureZoteroLibraryRemExists(plugin: RNPlugin) {
 	await plugin.storage.setSynced('zoteroLibraryRemId', rem._id);
 
 	await rem.setText(['Zotero Connector Home Page']);
-        await rem.addPowerup(powerupCodes.ZOTERO_CONNECTOR_HOME);
-        const autoSortEnabled = (await plugin.settings.getSetting(autoSortLibrarySettingID)) as
-                | boolean
-                | undefined;
-        if (autoSortEnabled) {
-                await rem.addPowerup(BuiltInPowerupCodes.AutoSort);
-        }
+	await rem.addPowerup(powerupCodes.ZOTERO_CONNECTOR_HOME);
+	const autoSortEnabled = (await plugin.settings.getSetting(autoSortLibrarySettingID)) as
+		| boolean
+		| undefined;
+	if (autoSortEnabled) {
+		await rem.addPowerup(BuiltInPowerupCodes.AutoSort);
+	}
 
 	await rem.setIsDocument(true); // TODO: we want this to be a folder rem! https://linear.app/remnoteio/issue/ENG-25553/add-a-remsetisfolder-to-the-plugin-system
 
@@ -197,8 +197,8 @@ export async function getZoteroLibraryRem(
 }
 
 export async function getUnfiledItemsRem(
-        plugin: RNPlugin,
-        libraryKey?: string
+	plugin: RNPlugin,
+	libraryKey?: string
 ): Promise<Rem | null> {
 	if (libraryKey) {
 		const map = (await plugin.storage.getSynced('unfiledRemMap')) as
@@ -218,24 +218,21 @@ export async function getUnfiledItemsRem(
 		await logMessage(plugin, 'Unfiled Power-Up not found!', LogType.Error, false);
 		return null;
 	}
-        const firstUnfiledZoteroItem = (await unfiledZoteroItemsPowerup.taggedRem())[0];
-        return firstUnfiledZoteroItem || null;
+	const firstUnfiledZoteroItem = (await unfiledZoteroItemsPowerup.taggedRem())[0];
+	return firstUnfiledZoteroItem || null;
 }
 
-export async function updateLibraryRemAutoSort(
-        plugin: RNPlugin,
-        enable: boolean
-): Promise<void> {
-        const libraryRem = await getZoteroLibraryRem(plugin);
-        if (!libraryRem) {
-                await logMessage(plugin, 'Zotero Library Rem not found', LogType.Error, false);
-                return;
-        }
-        if (enable) {
-                if (!(await libraryRem.hasPowerup(BuiltInPowerupCodes.AutoSort))) {
-                        await libraryRem.addPowerup(BuiltInPowerupCodes.AutoSort);
-                }
-        } else if (await libraryRem.hasPowerup(BuiltInPowerupCodes.AutoSort)) {
-                await libraryRem.removePowerup(BuiltInPowerupCodes.AutoSort);
-        }
+export async function updateLibraryRemAutoSort(plugin: RNPlugin, enable: boolean): Promise<void> {
+	const libraryRem = await getZoteroLibraryRem(plugin);
+	if (!libraryRem) {
+		await logMessage(plugin, 'Zotero Library Rem not found', LogType.Error, false);
+		return;
+	}
+	if (enable) {
+		if (!(await libraryRem.hasPowerup(BuiltInPowerupCodes.AutoSort))) {
+			await libraryRem.addPowerup(BuiltInPowerupCodes.AutoSort);
+		}
+	} else if (await libraryRem.hasPowerup(BuiltInPowerupCodes.AutoSort)) {
+		await libraryRem.removePowerup(BuiltInPowerupCodes.AutoSort);
+	}
 }

--- a/src/services/ensureUIPrettyZoteroRemExist.ts
+++ b/src/services/ensureUIPrettyZoteroRemExist.ts
@@ -1,5 +1,5 @@
 import { BuiltInPowerupCodes, type Rem, type RNPlugin } from '@remnote/plugin-sdk';
-import { powerupCodes } from '../constants/constants';
+import { powerupCodes, autoSortLibrarySettingID } from '../constants/constants';
 import { LogType, logMessage } from '../utils/logging';
 
 export async function ensureZoteroLibraryRemExists(plugin: RNPlugin) {
@@ -34,18 +34,30 @@ export async function ensureZoteroLibraryRemExists(plugin: RNPlugin) {
 		}
 	}
 
-	if (homeRem) {
-		await homeRem.setText(['Zotero Connector Home Page']);
-		if (!(await homeRem.hasPowerup(powerupCodes.ZOTERO_CONNECTOR_HOME))) {
-			await homeRem.addPowerup(powerupCodes.ZOTERO_CONNECTOR_HOME);
-		}
-		if (await homeRem.hasPowerup(powerupCodes.ZOTERO_SYNCED_LIBRARY)) {
-			await homeRem.removePowerup(powerupCodes.ZOTERO_SYNCED_LIBRARY);
-		}
-		await plugin.storage.setSynced('zoteroLibraryRemId', homeRem._id);
-		logMessage(plugin, 'Zotero Connector Home Page already exists', LogType.Info, false);
-		return homeRem;
-	}
+        if (homeRem) {
+                await homeRem.setText(['Zotero Connector Home Page']);
+                if (!(await homeRem.hasPowerup(powerupCodes.ZOTERO_CONNECTOR_HOME))) {
+                        await homeRem.addPowerup(powerupCodes.ZOTERO_CONNECTOR_HOME);
+                }
+                const autoSortEnabled = (await plugin.settings.getSetting(autoSortLibrarySettingID)) as
+                        | boolean
+                        | undefined;
+                if (autoSortEnabled) {
+                        if (!(await homeRem.hasPowerup(BuiltInPowerupCodes.AutoSort))) {
+                                await homeRem.addPowerup(BuiltInPowerupCodes.AutoSort);
+                        }
+                } else {
+                        if (await homeRem.hasPowerup(BuiltInPowerupCodes.AutoSort)) {
+                                await homeRem.removePowerup(BuiltInPowerupCodes.AutoSort);
+                        }
+                }
+                if (await homeRem.hasPowerup(powerupCodes.ZOTERO_SYNCED_LIBRARY)) {
+                        await homeRem.removePowerup(powerupCodes.ZOTERO_SYNCED_LIBRARY);
+                }
+                await plugin.storage.setSynced('zoteroLibraryRemId', homeRem._id);
+                logMessage(plugin, 'Zotero Connector Home Page already exists', LogType.Info, false);
+                return homeRem;
+        }
 
 	await logMessage(plugin, 'Zotero Connector Home Page Ensured', LogType.Info, false);
 
@@ -58,8 +70,13 @@ export async function ensureZoteroLibraryRemExists(plugin: RNPlugin) {
 	await plugin.storage.setSynced('zoteroLibraryRemId', rem._id);
 
 	await rem.setText(['Zotero Connector Home Page']);
-	await rem.addPowerup(powerupCodes.ZOTERO_CONNECTOR_HOME);
-	await rem.addPowerup(BuiltInPowerupCodes.AutoSort);
+        await rem.addPowerup(powerupCodes.ZOTERO_CONNECTOR_HOME);
+        const autoSortEnabled = (await plugin.settings.getSetting(autoSortLibrarySettingID)) as
+                | boolean
+                | undefined;
+        if (autoSortEnabled) {
+                await rem.addPowerup(BuiltInPowerupCodes.AutoSort);
+        }
 
 	await rem.setIsDocument(true); // TODO: we want this to be a folder rem! https://linear.app/remnoteio/issue/ENG-25553/add-a-remsetisfolder-to-the-plugin-system
 

--- a/src/services/ensureUIPrettyZoteroRemExist.ts
+++ b/src/services/ensureUIPrettyZoteroRemExist.ts
@@ -197,8 +197,8 @@ export async function getZoteroLibraryRem(
 }
 
 export async function getUnfiledItemsRem(
-	plugin: RNPlugin,
-	libraryKey?: string
+        plugin: RNPlugin,
+        libraryKey?: string
 ): Promise<Rem | null> {
 	if (libraryKey) {
 		const map = (await plugin.storage.getSynced('unfiledRemMap')) as
@@ -218,6 +218,24 @@ export async function getUnfiledItemsRem(
 		await logMessage(plugin, 'Unfiled Power-Up not found!', LogType.Error, false);
 		return null;
 	}
-	const firstUnfiledZoteroItem = (await unfiledZoteroItemsPowerup.taggedRem())[0];
-	return firstUnfiledZoteroItem || null;
+        const firstUnfiledZoteroItem = (await unfiledZoteroItemsPowerup.taggedRem())[0];
+        return firstUnfiledZoteroItem || null;
+}
+
+export async function updateLibraryRemAutoSort(
+        plugin: RNPlugin,
+        enable: boolean
+): Promise<void> {
+        const libraryRem = await getZoteroLibraryRem(plugin);
+        if (!libraryRem) {
+                await logMessage(plugin, 'Zotero Library Rem not found', LogType.Error, false);
+                return;
+        }
+        if (enable) {
+                if (!(await libraryRem.hasPowerup(BuiltInPowerupCodes.AutoSort))) {
+                        await libraryRem.addPowerup(BuiltInPowerupCodes.AutoSort);
+                }
+        } else if (await libraryRem.hasPowerup(BuiltInPowerupCodes.AutoSort)) {
+                await libraryRem.removePowerup(BuiltInPowerupCodes.AutoSort);
+        }
 }


### PR DESCRIPTION
## Summary
- allow enabling/disabling Auto Sort for the Zotero library Rem via new setting
- update library creation code to respect the new setting
- watch for setting changes to update the library Rem accordingly
- document the new option in the README

## Testing
- `npm run check-types`

------
https://chatgpt.com/codex/tasks/task_e_6875ce8c41308324bdec31d7d8119700