### PR TITLE
Limit plugin to single knowledge base

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The **Zotero** commands first send any detected source URLs to your Zotero libra
 -   **Force Zotero Sync** (`sync`) – immediately synchronize your Zotero library.
 -   **Abort Zotero Sync** – stop the current sync job.
 -   **Reset Synced Zotero Data** (`rszd`) – remove all Zotero Connector data from this knowledge base.
+-   **Knowledge Base ID** setting chooses which knowledge base Zotero Connector runs in.
 
 Additional diagnostic commands become available when **Debug Mode** is enabled.
 

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -14,12 +14,16 @@
 	"unlisted": true,
 	"description": "📚 Official Zotero Integration, Export Sources as Bibliography, and more!",
 	"requestNative": false,
-	"requiredScopes": [
-		{
-			"type": "All",
-			"level": "ReadCreateModify"
-		},
-		{
+        "requiredScopes": [
+                {
+                        "type": "All",
+                        "level": "ReadCreateModify"
+                },
+                {
+                        "type": "KnowledgeBaseInfo",
+                        "level": "Read"
+                },
+                {
 			"type": "Powerup",
 			"powerupCode": "zotero-synced-library",
 			"level": "ReadCreateModifyDelete"


### PR DESCRIPTION
## Summary
- restrict Zotero Connector to run only in one knowledge base
- request `KnowledgeBaseInfo` scope
- add Knowledge Base ID setting and docs

## Testing
- `npm run check-types`
- `npm run build` *(fails: ESBuildMinifyPlugin is not a constructor)*

------
https://chatgpt.com/codex/tasks/task_e_687d1de4e03083248e72b548173a4507