### PR TITLE
Limit plugin to single RemNote knowledge base

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -59,10 +59,13 @@
 			"powerupCode": "zotero-unfiled-items",
 			"level": "ReadCreateModifyDelete"
 		},
-		{
-			"type": "Powerup",
-			"powerupCode": "zotero-connector-home",
-			"level": "ReadCreateModifyDelete"
-		}
-	]
+                {
+                        "type": "Powerup",
+                        "powerupCode": "zotero-connector-home",
+                        "level": "ReadCreateModifyDelete"
+                },
+                {
+                        "type": "KnowledgeBaseInfo"
+                }
+        ]
 }

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -53,14 +53,17 @@ export const WIKIPEDIA_API_HEADERS = new Headers({
 // in case they need to contact me, they can find us by the name of the plugin or my username
 
 export const powerupCodes = {
-	ZOTERO_SYNCED_LIBRARY: 'zotero-synced-library',
-	ZITEM: 'zitem',
-	COLLECTION: 'collection',
-	ZOTERO_TAG: 'zotero-tag',
-	ZOTERO_NOTE: 'zotero-note',
-	ZITEM_ATTACHMENT: 'zitem-attachment',
-	// Historical name kept for compatibility
-	CITATION_POOL: 'coolPool',
-	ZOTERO_UNFILED_ITEMS: 'zotero-unfiled-items',
-	ZOTERO_CONNECTOR_HOME: 'zotero-connector-home',
+        ZOTERO_SYNCED_LIBRARY: 'zotero-synced-library',
+        ZITEM: 'zitem',
+        COLLECTION: 'collection',
+        ZOTERO_TAG: 'zotero-tag',
+        ZOTERO_NOTE: 'zotero-note',
+        ZITEM_ATTACHMENT: 'zitem-attachment',
+        // Historical name kept for compatibility
+        CITATION_POOL: 'coolPool',
+        ZOTERO_UNFILED_ITEMS: 'zotero-unfiled-items',
+        ZOTERO_CONNECTOR_HOME: 'zotero-connector-home',
 };
+
+export const ENABLED_KB_ID = 'enabled-kb-id';
+export const KNOWN_KBS = 'known-kbs';

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,17 +8,17 @@ import {
 } from '@remnote/plugin-sdk';
 import { fetchLibraries } from './api/zotero';
 import {
-        autoSortLibrarySettingID,
-        citationFormats,
-        citationSourceOptions,
-        escapeKeyID,
-        POPUP_Y_OFFSET,
-        powerupCodes,
-        selectItemKeyID,
-        selectNextKeyID,
-        selectPreviousKeyID,
-        ENABLED_KB_ID,
-        KNOWN_KBS,
+	autoSortLibrarySettingID,
+	citationFormats,
+	citationSourceOptions,
+	ENABLED_KB_ID,
+	escapeKeyID,
+	KNOWN_KBS,
+	POPUP_Y_OFFSET,
+	powerupCodes,
+	selectItemKeyID,
+	selectNextKeyID,
+	selectPreviousKeyID,
 } from './constants/constants';
 import { itemTypes } from './constants/zoteroItemSchema';
 import { autoSync } from './services/autoSync';
@@ -50,40 +50,7 @@ let citationWidgetId: string | undefined;
 // Helper functions for organizing registration logic
 
 async function registerSettings(plugin: RNPlugin) {
-        const kbInfo = await plugin.kb.getCurrentKnowledgeBaseData();
-        let knownKbs = (await plugin.storage.getSynced(KNOWN_KBS)) as
-                | Record<string, string>
-                | undefined;
-        if (!knownKbs) {
-                knownKbs = {};
-        }
-        if (!knownKbs[kbInfo._id]) {
-                knownKbs[kbInfo._id] = kbInfo.name;
-                await plugin.storage.setSynced(KNOWN_KBS, knownKbs);
-        }
-        let enabledKbId = (await plugin.storage.getSynced(ENABLED_KB_ID)) as
-                | string
-                | undefined;
-        if (!enabledKbId) {
-                enabledKbId = kbInfo._id;
-                await plugin.storage.setSynced(ENABLED_KB_ID, enabledKbId);
-        }
-
-        const kbOptions = Object.entries(knownKbs).map(([key, val]) => ({
-                key,
-                value: key,
-                label: val,
-        }));
-        await plugin.settings.registerDropdownSetting({
-                id: ENABLED_KB_ID,
-                title: 'Active Knowledge Base',
-                description:
-                        'Zotero Connector will only sync in the selected knowledge base.',
-                options: kbOptions,
-                defaultValue: enabledKbId,
-        });
-
-        // user sign-in
+	// user sign-in
 
 	await plugin.settings.registerStringSetting({
 		id: 'zotero-user-id',
@@ -96,6 +63,10 @@ async function registerSettings(plugin: RNPlugin) {
 		description:
 			'Find this at https://www.zotero.org/settings/keys. Make sure to enable all read/write for all features to work. But feel free to disable any you do not need.',
 	});
+
+	// select KB
+
+	await registerKBDropdownSettingPicker(plugin);
 
 	// selecting library
 
@@ -227,6 +198,38 @@ async function registerSettings(plugin: RNPlugin) {
 		title: 'Escape Key',
 		defaultValue: 'escape',
 		description: 'The key used to close the floating widget.',
+	});
+}
+
+async function registerKBDropdownSettingPicker(plugin: RNPlugin) {
+	const kbInfo = await plugin.kb.getCurrentKnowledgeBaseData();
+	let knownKbs = (await plugin.storage.getSynced(KNOWN_KBS)) as
+		| Record<string, string>
+		| undefined;
+	if (!knownKbs) {
+		knownKbs = {};
+	}
+	if (!knownKbs[kbInfo._id]) {
+		knownKbs[kbInfo._id] = kbInfo.name;
+		await plugin.storage.setSynced(KNOWN_KBS, knownKbs);
+	}
+	let enabledKbId = (await plugin.storage.getSynced(ENABLED_KB_ID)) as string | undefined;
+	if (!enabledKbId) {
+		enabledKbId = kbInfo._id;
+		await plugin.storage.setSynced(ENABLED_KB_ID, enabledKbId);
+	}
+
+	const kbOptions = Object.entries(knownKbs).map(([key, val]) => ({
+		key,
+		value: key,
+		label: val,
+	}));
+	await plugin.settings.registerDropdownSetting({
+		id: ENABLED_KB_ID,
+		title: 'Active Knowledge Base',
+		description: 'Zotero Connector will only sync in the selected knowledge base.',
+		options: kbOptions,
+		defaultValue: enabledKbId,
 	});
 }
 
@@ -883,16 +886,16 @@ async function registerCommands(plugin: RNPlugin) {
 }
 
 async function onActivate(plugin: RNPlugin) {
-        await registerSettings(plugin);
-        const kbInfo = await plugin.kb.getCurrentKnowledgeBaseData();
-        const enabledKb = (await plugin.storage.getSynced(ENABLED_KB_ID)) as string | undefined;
-        if (enabledKb && enabledKb !== kbInfo._id) {
-                await plugin.app.toast(
-                        'Zotero Connector is disabled in this knowledge base. Update settings to enable.'
-                );
-                return;
-        }
-        await registerPowerups(plugin);
+	await registerSettings(plugin);
+	const kbInfo = await plugin.kb.getCurrentKnowledgeBaseData();
+	const enabledKb = (await plugin.storage.getSynced(ENABLED_KB_ID)) as string | undefined;
+	if (enabledKb && enabledKb !== kbInfo._id) {
+		await plugin.app.toast(
+			'Zotero Connector is disabled in this knowledge base. Update settings to enable.'
+		);
+		return;
+	}
+	await registerPowerups(plugin);
 	setupThemeDetection(plugin, async () => {
 		await registerIconCSS(plugin, detectDarkMode());
 	});
@@ -940,10 +943,10 @@ async function onActivate(plugin: RNPlugin) {
 	let lastLibrary: string | undefined;
 	let lastDisable: boolean | undefined;
 	let lastMulti: boolean | undefined;
-        let lastCitationSource: string | undefined;
-        let lastAutoSortLibrary: boolean | undefined;
-        let lastEnabledKb: string | undefined;
-        let debugRegistered = false;
+	let lastCitationSource: string | undefined;
+	let lastAutoSortLibrary: boolean | undefined;
+	let lastEnabledKb: string | undefined;
+	let debugRegistered = false;
 	let syncTimeout: NodeJS.Timeout | undefined;
 
 	function scheduleSync(p: RNPlugin) {
@@ -972,18 +975,18 @@ async function onActivate(plugin: RNPlugin) {
 			return;
 		}
 
-                const apiKey = (await reactivePlugin.settings.getSetting('zotero-api-key')) as
-                        | string
-                        | undefined;
-                const userId = (await reactivePlugin.settings.getSetting('zotero-user-id')) as
-                        | string
-                        | undefined;
-                const enabledKbSetting = (await reactivePlugin.settings.getSetting(ENABLED_KB_ID)) as
-                        | string
-                        | undefined;
-                const libraryId = (await reactivePlugin.settings.getSetting('zotero-library-id')) as
-                        | string
-                        | undefined;
+		const apiKey = (await reactivePlugin.settings.getSetting('zotero-api-key')) as
+			| string
+			| undefined;
+		const userId = (await reactivePlugin.settings.getSetting('zotero-user-id')) as
+			| string
+			| undefined;
+		const enabledKbSetting = (await reactivePlugin.settings.getSetting(ENABLED_KB_ID)) as
+			| string
+			| undefined;
+		const libraryId = (await reactivePlugin.settings.getSetting('zotero-library-id')) as
+			| string
+			| undefined;
 		const disable = (await reactivePlugin.settings.getSetting('disable-auto-sync')) as
 			| boolean
 			| undefined;
@@ -1005,22 +1008,22 @@ async function onActivate(plugin: RNPlugin) {
 		}
 
 		const hasLibrary = multi ? true : Boolean(libraryId);
-                if (
-                        apiKey &&
-                        userId &&
-                        hasLibrary &&
-                        (apiKey !== lastApiKey || userId !== lastUserId || multiChanged)
-                ) {
-                        scheduleSync(reactivePlugin);
-                        lastApiKey = apiKey;
-                        lastUserId = userId;
-                        lastMulti = multi;
-                }
+		if (
+			apiKey &&
+			userId &&
+			hasLibrary &&
+			(apiKey !== lastApiKey || userId !== lastUserId || multiChanged)
+		) {
+			scheduleSync(reactivePlugin);
+			lastApiKey = apiKey;
+			lastUserId = userId;
+			lastMulti = multi;
+		}
 
-                if (enabledKbSetting !== lastEnabledKb) {
-                        await reactivePlugin.storage.setSynced(ENABLED_KB_ID, enabledKbSetting);
-                        lastEnabledKb = enabledKbSetting;
-                }
+		if (enabledKbSetting !== lastEnabledKb) {
+			await reactivePlugin.storage.setSynced(ENABLED_KB_ID, enabledKbSetting);
+			lastEnabledKb = enabledKbSetting;
+		}
 
 		if (disable !== lastDisable) {
 			lastDisable = disable;


### PR DESCRIPTION
## Summary
- store list of known knowledge bases and default to current KB
- add `enabled-kb-id` dropdown in settings
- prevent plugin from running in other KBs
- watch for knowledge base setting changes
- request `KnowledgeBaseInfo` permission

## Testing
- `npm run check-types`


------
https://chatgpt.com/codex/tasks/task_e_687d1de4e03083248e72b548173a4507