### PR TITLE
Type safety for library lookup

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -196,8 +196,30 @@ export type Collection = {
 };
 
 export interface RemNode {
-	remId: string;
-	zoteroId: string;
-	zoteroParentId: string | string[] | null;
-	rem: Rem;
+        remId: string;
+        zoteroId: string;
+        zoteroParentId: string | string[] | null;
+        rem: Rem;
+}
+
+/**
+ * Minimal user object returned from the Zotero API when fetching the current user.
+ */
+export interface ZoteroUserResponse {
+       data?: {
+               profileName?: string;
+               username?: string;
+       };
+}
+
+/**
+ * Minimal group object returned when listing user groups via the Zotero API.
+ */
+export interface ZoteroGroupListItem {
+       id?: number | string;
+       name?: string;
+       data?: {
+               id?: number | string;
+               name?: string;
+       };
 }


### PR DESCRIPTION
## Summary
- type the user/group API responses
- use the new interfaces when fetching libraries

## Testing
- `npm run check-types`

------
https://chatgpt.com/codex/tasks/task_e_687d2363b1c08324b91faa4b8b45e65c