### PR TITLE
Implement Zotero note update helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,20 @@ Additional diagnostic commands become available when **Debug Mode** is enabled.
 -   **Debug Mode (Zotero Connector)** – exposes extra diagnostic commands and enables verbose logging. (please use this when reporting bugs and sending console logs! 🙏)
 -   **Select Next Key** – key to move down in the citation finder widget.
 -   **Select Previous Key** – key to move up in the citation finder widget.
--   **Select Item Key** – key to insert the selected citation.
--   **Escape Key** – key to close the citation finder widget.
--   -->
+ -   **Select Item Key** – key to insert the selected citation.
+ -   **Escape Key** – key to close the citation finder widget.
+
+## Programmatic API
+
+Use `updateNote` to push edited notes back to Zotero:
+
+```ts
+import { updateNote } from './src/api/zotero';
+await updateNote(plugin, 'ITEM_KEY', '<p>updated text</p>', 5);
+```
+
+The helper issues a `PATCH` request with `If-Unmodified-Since-Version` to avoid overwriting newer changes.
+-->
 
 ## Development Roadmap
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import {
 	type RNPlugin,
 	WidgetLocation,
 } from '@remnote/plugin-sdk';
-import { fetchLibraries } from './api/zotero';
+import { fetchLibraries, updateNote } from './api/zotero';
 import {
 	autoSortLibrarySettingID,
 	citationFormats,
@@ -818,11 +818,26 @@ async function registerCommands(plugin: RNPlugin) {
 		});
 	}
 
-	plugin.event.addListener(AppEvents.EditorTextEdited, undefined, async () => {
-		if (citationWidgetId && (await plugin.window.isFloatingWidgetOpen(citationWidgetId))) {
-			return;
-		}
-	});
+        plugin.event.addListener(AppEvents.EditorTextEdited, undefined, async () => {
+                if (citationWidgetId && (await plugin.window.isFloatingWidgetOpen(citationWidgetId))) {
+                        return;
+                }
+
+                const rem = await plugin.focus.getFocusedRem();
+                if (!rem) return;
+                if (!(await rem.hasPowerup(powerupCodes.ZOTERO_NOTE))) return;
+
+                const key = await rem.getPowerupProperty(powerupCodes.ZITEM, 'key');
+                const verStr = await rem.getPowerupProperty(powerupCodes.ZITEM, 'version');
+                if (!key || !verStr) return;
+
+                try {
+                        const html = await plugin.richText.toHTML(rem.text ?? []);
+                        await updateNote(plugin, String(key), html, Number(verStr));
+                } catch (err) {
+                        await logMessage(plugin, 'Failed to update Zotero note', LogType.Error, false, String(err));
+                }
+        });
 
 	await plugin.app.registerCommand({
 		id: 'insert-citation-at-cursor',


### PR DESCRIPTION
## Summary
- add `updateNote` helper for sending PATCH requests to Zotero
- expose new helper and document basic usage
- update plugin to send note edits back to Zotero

## Testing
- `npm run check-types`


------
https://chatgpt.com/codex/tasks/task_e_687d3b2631608324a1d12bd93025903a